### PR TITLE
Rememeber specific message

### DIFF
--- a/src/commands/remember/basicRemember.js
+++ b/src/commands/remember/basicRemember.js
@@ -1,0 +1,60 @@
+const {ApplicationCommandOptionType} = require('discord.js');
+const {addMessage, parseMessage, searchAllChannelsForMessage} = require("../../utils/rememberMessages");
+const { testServer } = require('../../../config.json');
+
+//remembers a message based on a message id parameter
+module.exports = {
+    name: 'remember',
+    description: 'Stores a message from the current channel based on its message-id',
+    options:  [
+        {
+            name: 'message-id',
+            description: 'The id of the message',
+            required: true,
+            type: ApplicationCommandOptionType.String,
+        },
+        {
+            name: 'search-all-channels',
+            description: 'Searches all channels for the message instead of the current channel.',
+            type: ApplicationCommandOptionType.Boolean,
+        },
+    ],
+
+    //logic, 
+    callback: async(client, interaction) =>{
+        
+        try{
+            await interaction.deferReply(); //defer waits for logic to finish
+            //get the id    
+            const id = interaction.options.get('message-id').value;
+            const s = interaction.options.getBoolean('search-all-channels') ?? false;
+            
+            let msg;
+            //if true, search all
+            if(s){
+                msg = await searchAllChannelsForMessage(id, client, testServer);
+            }
+            else{
+                //get the message from current channel
+                msg =  await interaction.channel.messages.fetch(id);
+            }
+
+            //parse the message
+            const parsedMessage = parseMessage(msg);
+
+            //save the message
+            addMessage(parsedMessage);
+
+            await interaction.editReply({
+              content:`Remembered: "${msg.content}"`,
+              ephemeral: false,
+            });
+        }
+        catch(error){ 
+            await interaction.editReply({
+                content:`Unable to find message. ${error}`,
+                ephemeral: false,
+            }); 
+        }
+    }
+};

--- a/src/commands/remember/basicRemember.js
+++ b/src/commands/remember/basicRemember.js
@@ -14,6 +14,11 @@ module.exports = {
             type: ApplicationCommandOptionType.String,
         },
         {
+            name: 'search-specific-channel',
+            description: 'Searches the give channel for the message.',
+            type: ApplicationCommandOptionType.String,
+        },
+        {
             name: 'search-all-channels',
             description: 'Searches all channels for the message instead of the current channel.',
             type: ApplicationCommandOptionType.Boolean,
@@ -25,18 +30,28 @@ module.exports = {
         
         try{
             await interaction.deferReply(); //defer waits for logic to finish
-            //get the id    
-            const id = interaction.options.get('message-id').value;
+            
+            //get the id of the message  
+            const idMessage = interaction.options.get('message-id').value;
+            //channel id
+            const specificChannelId = interaction.options.getString('search-specific-channel');
+            //search all channels?
             const s = interaction.options.getBoolean('search-all-channels') ?? false;
             
             let msg;
-            //if true, search all
-            if(s){
-                msg = await searchAllChannelsForMessage(id, client, testServer);
+            //specific channel is true, search that channel
+            if(specificChannelId){
+                //get the message from given channel
+                const channel = await client.channels.cache.get(specificChannelId);
+                msg =  await channel.messages.fetch(idMessage);
+            }
+            //else if 
+            else if(s){
+                msg = await searchAllChannelsForMessage(idMessage, client, testServer);
             }
             else{
                 //get the message from current channel
-                msg =  await interaction.channel.messages.fetch(id);
+                msg =  await interaction.channel.messages.fetch(idMessage);
             }
 
             //parse the message

--- a/src/commands/remember/printStoredMessages.js
+++ b/src/commands/remember/printStoredMessages.js
@@ -1,0 +1,30 @@
+const {getRememberedMessage} = require("../../utils/rememberMessages");
+
+//remembers a message based on a message id parameter
+module.exports = {
+    name: 'print-storage',
+    description: 'Stores a message from the current channel based on its message-id',
+
+    //logic, 
+    callback: async(client, interaction) =>{
+        
+        try{
+            await interaction.deferReply();
+            const messages = getRememberedMessage();
+            let print = "Messages: ";
+            messages.forEach(async(msg)=>{
+                print+=`\n${msg.content}`;
+            });
+            await interaction.editReply({
+                content:`Message ${print}`,
+                ephemeral: false,
+            });          
+        }
+        catch(error){ 
+            await interaction.editReply({
+                content:`Unable to find message. ${error}`,
+                ephemeral: false,
+            }); 
+        }
+    }
+};

--- a/src/commands/remember/printStoredMessages.js
+++ b/src/commands/remember/printStoredMessages.js
@@ -1,5 +1,7 @@
 const {getRememberedMessage} = require("../../utils/rememberMessages");
 
+const fs = require('fs');
+
 //remembers a message based on a message id parameter
 module.exports = {
     name: 'print-storage',
@@ -13,12 +15,30 @@ module.exports = {
             const messages = getRememberedMessage();
             let print = "Messages: ";
             messages.forEach(async(msg)=>{
-                print+=`\n${msg.content}`;
+                print+=`
+                ${msg.content}
+                `;
             });
+            
+
+            const path = './storedFiles/storage.txt';
+            fs.writeFile(path, print, error =>{
+                if(error) console.log(error); 
+                return;
+            });
+
+            interaction.channel.send({
+                files: [{
+                    attachment: path,
+                    name: 'storage.txt'
+                }],
+            });
+
             await interaction.editReply({
-                content:`Message ${print}`,
+                content:`Sent Message`,
                 ephemeral: false,
-            });          
+            });
+                      
         }
         catch(error){ 
             await interaction.editReply({

--- a/src/handlers/eventHandler.js
+++ b/src/handlers/eventHandler.js
@@ -22,7 +22,6 @@ module.exports = (client) =>{
             for(const eventFile of eventFiles){
                 const eventFunction = require(eventFile);
                 await eventFunction(client, arg);
-                console.log(eventFile);
             }
         })
     }

--- a/src/utils/getAllTextChannels.js
+++ b/src/utils/getAllTextChannels.js
@@ -1,0 +1,15 @@
+//gets all the text channels in the guild
+module.exports = async(client, guildId) => {
+    //get the guild
+    const guild = await client.guilds.fetch(guildId);
+
+    const channels = guild.channels.cache;
+
+    let textChannels = [];
+
+    channels.forEach(channel => {
+        if(channel.type === 0) 
+            textChannels.push(channel);
+    });
+    return textChannels;
+};

--- a/src/utils/rememberMessages.js
+++ b/src/utils/rememberMessages.js
@@ -1,0 +1,80 @@
+const getAllTextChannels = require('./getAllTextChannels');
+
+const rememberedMessages = []
+
+const addMessage = (message) => { rememberedMessages.push(message);}
+const getRememberedMessage = () => { return rememberedMessages }
+const clearRememeberedMessage = () => { rememberedMessages = [] }
+
+//this parses into an object
+const parseMessage = (msg) => { 
+    const message = {
+        content: msg.content,
+        authorId: msg.author.id,
+        authorGlobalName: msg.author.globalName,
+        timestamp: msg.createdTimestamp
+    }
+
+    return message;
+}
+
+//searches all channels for the message
+const searchAllChannelsForMessage = async (id, client, guildId) => { 
+    //get all channels
+    let channels = await getAllTextChannels(client, guildId);
+
+    //loop through and attempt to find message
+    channels =  Array.from(channels);
+
+    for(let i = 0; i < channels.length; i++){
+        try{
+            const msg = await channels[i].messages.fetch(id);
+            return msg;
+
+        }catch(error){
+            console.log(`${channels[i].name} did not have the message`);
+        }
+    }
+}
+
+//returns the id of the message at the final index
+const saveNumberMessages = async(numberToSave, channel, id) =>{
+    let messages;
+    //get the messages
+
+    if (id) 
+        messages = await channel.messages.fetch({ limit: numberToSave, start: id });
+    else
+        messages = await channel.messages.fetch({ limit: numberToSave});
+            
+    //loop for each message
+    //using a amalgamation of a for + foreach to keep track
+    //feel free to refactor!!!
+    let i = 1;
+    let returnId;
+    messages.forEach((msg)=>{
+                    
+        //parse the message
+        const parsedMessage = parseMessage(msg);
+    
+        //save the message
+        addMessage(parsedMessage);
+
+        //return the index if its the final one
+        if(i == numberToSave)
+            returnId = msg.id;
+        i++;
+    });
+    return returnId;  
+}
+
+
+
+module.exports = {
+    addMessage,
+    getRememberedMessage,
+    clearRememeberedMessage,
+    parseMessage,
+    searchAllChannelsForMessage,
+    saveNumberMessages
+ }

--- a/storedFiles/storage.txt
+++ b/storedFiles/storage.txt
@@ -1,0 +1,3 @@
+Messages: 
+                Claim a role below.
+                


### PR DESCRIPTION
Description
Use `/remember` with a id option to remember a message with that id

Parameters

- `message-id` - the id of the message to remember. 

- `search-specific-channel` - id of the channel to search in (optional)

- `search-all-channels` - bool to specify a search of all channels for the message. (optional)

Use `/print-storage` to print out the storage in the form of a text file. There is a folder in Bot called storedFiles with a text file `storage.txt`. This command overwrites the file with the data contained in the remember object array and sends it as a message.

Parameters: None

Notes:

Multiple functions were added to Utils:
`getAllTextChannels` Gets all the text channels in the guild.
`rememberMessages.js` 
- `searchAllChannelsForMessage` which does as its name states given a message id, guildId, and the client.
- `parseMessage` which takes a message object and saves a few of its pieces of data into an object.
- `saveNumberMessages` which saves up to a number of messages given a channel, and returns the id of the last message. It is not used in this, but I left it from the count remember rather than do extra file shuffling from the whole new branch file structure fiasco of yesterday.
