### PR TITLE
Updated Linting Rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,15 +6,11 @@ export default [
     {
         files: ['**/*.js'],
         languageOptions:
-        {
-            sourceType: 'commonjs',
-        }
+        {sourceType: 'commonjs',}
     },
     {
         languageOptions:
-        {
-            globals: globals.node
-        }
+        {globals: globals.node}
     },
 
     pluginJs.configs.recommended,
@@ -30,22 +26,17 @@ export default [
     {
 
         // Stylistic rules documentation: https://eslint.style/packages/js
-        plugins: {
-            '@stylistic/js': stylisticJs
-        },
-        rules: {
+        plugins: {'@stylistic/js': stylisticJs},
+        rules:   {
 
             // 0 - off. 1 - warn. 2 - error
             // can use strings. ex: 'warn' 
-            'semi':                     [1, 'always'],
-            'no-mixed-spaces-and-tabs': ['warn', 'smart-tabs'],
-            'quotes':                   [1, 'single', { 'allowTemplateLiterals': true, 'avoidEscape': true }],
-            'arrow-parens':             [1, 'as-needed'],
-            'array-bracket-newline':    [1, { 'multiline': true }],
-            'block-spacing':            [1, 'always'],
-            'brace-style':              [1, '1tbs', { 'allowSingleLine': true}],
-            'comma-dangle':             [
-                0, 
+            'arrow-parens':          [1, 'as-needed'],
+            'array-bracket-newline': [1, { 'multiline': true }],
+            'block-spacing':         [1, 'always'],
+            'brace-style':           [1, '1tbs', { 'allowSingleLine': true}],
+            'comma-dangle':          [
+                0,
                 'always',
                 {
                     'arrays':    'always',
@@ -77,12 +68,64 @@ export default [
             'no-confusing-arrow':       [1, {'allowParens': true, 'onlyOneSimpleParam': true}],
             'no-extra-parens':          [
                 1, 'all', {
-                    'nestedBinaryExpressions':          false, 
-                    'ternaryOperandBinaryExpressions':  false, 
-                    'enforceForArrowConditionals':      false, 
+                    'nestedBinaryExpressions':          false,
+                    'ternaryOperandBinaryExpressions':  false,
+                    'enforceForArrowConditionals':      false,
                     'enforceForNewInMemberExpressions': false
                 }
-            ]
+            ],
+            'no-extra-semi':            1,
+            'no-floating-decimal':      1,
+            'no-mixed-spaces-and-tabs': ['warn', 'smart-tabs'],
+            'no-multi-spaces':          [
+                1,
+                {
+                    'ignoreEOLComments': true,
+                    'exceptions':        {
+                        'Property':           true,
+                        'VariableDeclarator': true,
+                        'ImportDeclaration':  true,
+                    }
+                }
+            ],
+            'no-trailing-spaces':               [1, {'ignoreComments': true}],
+            'no-whitespace-before-property':    1,
+            'nonblock-statement-body-position': [0, 'beside'],
+            'object-curly-newline':             [
+                1, {
+                    'multiline':     true,
+                    'minProperties': 4,
+                }
+            ],
+            'object-property-newline':         [1, {'allowAllPropertiesOnSameLine': true}],
+            'operator-linebreak':              [1, 'after', {'overrides': {}}],
+            'padded-blocks':                   [0, 'never'],
+            'padding-line-between-statements': 0, // https://eslint.style/rules/js/padding-line-between-statements
+            'quote-props':                     [
+                1, 'as-needed', {
+                    'numbers':     true,
+                    'keywords':    true,
+                    'unnecessary': false
+                }
+            ],
+            'quotes':                      [1, 'single', { 'allowTemplateLiterals': true, 'avoidEscape': true }],
+            'rest-spread-spacing':         [1, 'never'],
+            'semi':                        [1, 'always'],
+            'semi-spacing':                1,
+            'semi-style':                  [0, 'last'],
+            'space-before-blocks':         1,
+            'space-before-function-paren': [0, 'always'],
+            'space-in-parens':             [1, 'never'],
+            'space-infix-ops':             1,
+            'space-unary-ops':             [1, {'words': true, 'nonwords': false}],
+            'spaced-comment':              [1, 'always'],
+            'switch-colon-spacing':        [1, {'after': true, 'before': false}],
+            'template-curly-spacing':      [0, 'never'],
+            'wrap-iife':                   [1, 'any'],
+            'wrap-regex':                  1,
+            'yield-star-spacing':          0,
+
+
 
             // ...
         }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,36 +6,84 @@ export default [
     {
         files: ['**/*.js'],
         languageOptions:
-    {
-        sourceType: 'commonjs',
-    }
+        {
+            sourceType: 'commonjs',
+        }
     },
     {
         languageOptions:
-    {
-        globals: globals.node
-    }
+        {
+            globals: globals.node
+        }
     },
 
     pluginJs.configs.recommended,
     {
+
         // ESLint rules documentation: https://eslint.org/docs/latest/rules
         'rules': {
             'consistent-return': 2,
-            'no-else-return': 1,
-            'space-unary-ops': 2
+            'no-else-return':    1,
+            'space-unary-ops':   2
         }
     },
     {
+
         // Stylistic rules documentation: https://eslint.style/packages/js
         plugins: {
             '@stylistic/js': stylisticJs
         },
         rules: {
-            'indent': ['warn', 4],
-            'semi': [1, 'always'],
+
+            // 0 - off. 1 - warn. 2 - error
+            // can use strings. ex: 'warn' 
+            'semi':                     [1, 'always'],
             'no-mixed-spaces-and-tabs': ['warn', 'smart-tabs'],
-            'quotes': [1, 'single', {'allowTemplateLiterals': true, 'avoidEscape': true}]
+            'quotes':                   [1, 'single', { 'allowTemplateLiterals': true, 'avoidEscape': true }],
+            'arrow-parens':             [1, 'as-needed'],
+            'array-bracket-newline':    [1, { 'multiline': true }],
+            'block-spacing':            [1, 'always'],
+            'brace-style':              [1, '1tbs', { 'allowSingleLine': true}],
+            'comma-dangle':             [
+                0, 
+                'always',
+                {
+                    'arrays':    'always',
+                    'objects':   'always',
+                    'imports':   'always',
+                    'exports':   'always',
+                    'functions': 'always'
+                }
+            ],
+            'comma-spacing':                  [1, { 'after': true}],
+            'computed-property-spacing':      [1, 'never'],
+            'dot-location':                   [1, 'property'],
+            'eol-last':                       [1, 'always'],
+            'func-call-spacing':              [1, 'never'],
+            'function-call-argument-newline': [1, 'consistent'],
+            'function-paren-newline':         [1, 'multiline'],
+            'implicit-arrow-linebreak':       [0, 'beside'],
+            'indent':                         [1, 4],
+            'jsx-quotes':                     [1, 'prefer-double'],
+            'key-spacing':                    [1, {'align': 'value', 'beforeColon': false}],
+            'keyword-spacing':                [1, {'before': true, 'after': true}],
+            'lines-around-comment':           [1, {'beforeBlockComment': true, 'beforeLineComment': true}],
+
+            // ignores jsdocs
+            'multiline-comment-style':  [0, 'separate-lines'],
+            'multiline-ternary':        [1, 'always-multiline'],
+            'new-parens':               [1, 'always'],
+            'newline-per-chained-call': [1, {'ignoreChainWithDepth': 3}],
+            'no-confusing-arrow':       [1, {'allowParens': true, 'onlyOneSimpleParam': true}],
+            'no-extra-parens':          [
+                1, 'all', {
+                    'nestedBinaryExpressions':          false, 
+                    'ternaryOperandBinaryExpressions':  false, 
+                    'enforceForArrowConditionals':      false, 
+                    'enforceForNewInMemberExpressions': false
+                }
+            ]
+
             // ...
         }
     }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,11 +6,11 @@ export default [
     {
         files: ['**/*.js'],
         languageOptions:
-        {sourceType: 'commonjs',}
+        { sourceType: 'commonjs', }
     },
     {
         languageOptions:
-        {globals: globals.node}
+        { globals: globals.node }
     },
 
     pluginJs.configs.recommended,
@@ -26,7 +26,7 @@ export default [
     {
 
         // Stylistic rules documentation: https://eslint.style/packages/js
-        plugins: {'@stylistic/js': stylisticJs},
+        plugins: { '@stylistic/js': stylisticJs },
         rules:   {
 
             // 0 - off. 1 - warn. 2 - error
@@ -34,7 +34,7 @@ export default [
             'arrow-parens':          [1, 'as-needed'],
             'array-bracket-newline': [1, { 'multiline': true }],
             'block-spacing':         [1, 'always'],
-            'brace-style':           [1, '1tbs', { 'allowSingleLine': true}],
+            'brace-style':           [1, '1tbs', { 'allowSingleLine': true }],
             'comma-dangle':          [
                 0,
                 'always',
@@ -46,7 +46,7 @@ export default [
                     'functions': 'always'
                 }
             ],
-            'comma-spacing':                  [1, { 'after': true}],
+            'comma-spacing':                  [1, { 'after': true }],
             'computed-property-spacing':      [1, 'never'],
             'dot-location':                   [1, 'property'],
             'eol-last':                       [1, 'always'],
@@ -56,16 +56,16 @@ export default [
             'implicit-arrow-linebreak':       [0, 'beside'],
             'indent':                         [1, 4],
             'jsx-quotes':                     [1, 'prefer-double'],
-            'key-spacing':                    [1, {'align': 'value', 'beforeColon': false}],
-            'keyword-spacing':                [1, {'before': true, 'after': true}],
-            'lines-around-comment':           [1, {'beforeBlockComment': true, 'beforeLineComment': true}],
+            'key-spacing':                    [1, { 'align': 'value', 'beforeColon': false }],
+            'keyword-spacing':                [1, { 'before': true, 'after': true }],
+            'lines-around-comment':           [1, { 'beforeBlockComment': true, 'beforeLineComment': true }],
 
             // ignores jsdocs
             'multiline-comment-style':  [0, 'separate-lines'],
             'multiline-ternary':        [1, 'always-multiline'],
             'new-parens':               [1, 'always'],
-            'newline-per-chained-call': [1, {'ignoreChainWithDepth': 3}],
-            'no-confusing-arrow':       [1, {'allowParens': true, 'onlyOneSimpleParam': true}],
+            'newline-per-chained-call': [1, { 'ignoreChainWithDepth': 3 }],
+            'no-confusing-arrow':       [1, { 'allowParens': true, 'onlyOneSimpleParam': true }],
             'no-extra-parens':          [
                 1, 'all', {
                     'nestedBinaryExpressions':          false,
@@ -88,17 +88,18 @@ export default [
                     }
                 }
             ],
-            'no-trailing-spaces':               [1, {'ignoreComments': true}],
+            'no-trailing-spaces':               [1, { 'ignoreComments': true }],
             'no-whitespace-before-property':    1,
             'nonblock-statement-body-position': [0, 'beside'],
+            'object-curly-spacing':             [1, 'always'],
             'object-curly-newline':             [
                 1, {
                     'multiline':     true,
                     'minProperties': 4,
                 }
             ],
-            'object-property-newline':         [1, {'allowAllPropertiesOnSameLine': true}],
-            'operator-linebreak':              [1, 'after', {'overrides': {}}],
+            'object-property-newline':         [1, { 'allowAllPropertiesOnSameLine': true }],
+            'operator-linebreak':              [1, 'after', { 'overrides': {} }],
             'padded-blocks':                   [0, 'never'],
             'padding-line-between-statements': 0, // https://eslint.style/rules/js/padding-line-between-statements
             'quote-props':                     [
@@ -117,9 +118,9 @@ export default [
             'space-before-function-paren': [0, 'always'],
             'space-in-parens':             [1, 'never'],
             'space-infix-ops':             1,
-            'space-unary-ops':             [1, {'words': true, 'nonwords': false}],
+            'space-unary-ops':             [1, { 'words': true, 'nonwords': false }],
             'spaced-comment':              [1, 'always'],
-            'switch-colon-spacing':        [1, {'after': true, 'before': false}],
+            'switch-colon-spacing':        [1, { 'after': true, 'before': false }],
             'template-curly-spacing':      [0, 'never'],
             'wrap-iife':                   [1, 'any'],
             'wrap-regex':                  1,

--- a/examples/linterBadExample.js
+++ b/examples/linterBadExample.js
@@ -1,30 +1,121 @@
 
-let foo;
-let fuz;
+
+// no space before comment
+
+
+// semicolons required
+
+let foo = 'foo';
+let fuz = 'fuz'; // double quote not preferred
+let foz = 'foz';
+
+// multiline-ternary
+// operator-linebreak
+let fiz = foo ? foo : // inconsistent line break
+    fuz;
+
+fiz = fiz ?
+    fiz :
+    foo ?
+        foo :
+        fuz; // operator before
 
 // array-bracket-newline
-let arr = [1, 2, 3];
+let arr = [ 1, 2, 3 ]; // space between brackets
 let azz = [
-    1,
-    2, 
+    1, 2, // // no line break before multi-line array
     3
 ];
 
-let bar = () => {
+// space-infix-ops
+let math = 5 + 2 + 3; // no space between
 
+// space-unary-ops
+math++; // space between
+
+// key-spacing (objects)
+// object-property-newline
+// quote-props
+let obj = {
+    shorter:      'short',
+    'longerName': 'long',
+    'quote-prop': 'required quotes',
+    '123':        '123' // numbers must have quotes
 };
 
-// arrow parens
-let baz = foo => true;
+// object-curly-newline
+let inline_obj = {foo, fuz, fiz};
+let inline_long_obj = {
+    foo, fuz, fiz, foz
+}; // too long
 
+// rest-spread-spacing
+let spread_obj = { ...inline_obj}; // space between spread
+
+
+// arrow parens
+let bar = () => {};
+
+let baz = foo => 'baz'; // parens not needed
+
+// block spacing
+let bab = (foo, fuz) => { return true; };
+
+// function-call-argument-newline
+bab(foo, fuz);
+bab(
+    foo, // needs newline for multi-line
+    fuz
+);
+
+// function-call-spacing
+if (foo) bar(); // spaces
 
 // brace styles 
-if (foo) bar();
-
-if (foo) {
+// space-before-blocks
+if (foo) { // bracket in wrong location
     bar();
 } else if (fuz) {
     bar();
-} else {
+} else { // else in wrong location
     baz();
 }
+
+class Foo {
+    constructor() {
+        this.foo = foo;
+        this.fuz = fuz;
+    }
+
+    // computed property spacing for classes
+    [baz()] () { // spaces in property name
+        return this;
+    }
+}
+
+// multiline-comment-style (currently disabled)
+// new-parens
+// dot-location
+new Foo().baz() // inconsistent chaining
+    .baz() // dot should be before prop
+    .foo;
+new Foo().baz().baz()
+    .baz()
+    .baz().foo; // too long
+
+// switch-colon-spacing
+switch (foo) {
+case 'foo': break; // space after case 'foo'
+case 'bar': break;
+}
+
+// wrap-iife
+// any wrapping is actually allowed
+(function() {})();
+(function() {})();
+
+// wrap regex
+(/foo/).test('bar'); // must wrap in parentheses
+'foo'.replace(/foo/, 'bar'); // this is fine
+
+// eol-last: new line at EOF

--- a/examples/linterBadExample.js
+++ b/examples/linterBadExample.js
@@ -1,0 +1,30 @@
+
+let foo;
+let fuz;
+
+// array-bracket-newline
+let arr = [1, 2, 3];
+let azz = [
+    1,
+    2, 
+    3
+];
+
+let bar = () => {
+
+};
+
+// arrow parens
+let baz = foo => true;
+
+
+// brace styles 
+if (foo) bar();
+
+if (foo) {
+    bar();
+} else if (fuz) {
+    bar();
+} else {
+    baz();
+}

--- a/examples/linterBadExample.js
+++ b/examples/linterBadExample.js
@@ -1,83 +1,82 @@
 
 
-// no space before comment
+//no space before comment
 
 
 // semicolons required
 
-let foo = 'foo';
-let fuz = 'fuz'; // double quote not preferred
-let foz = 'foz';
+let foo = 'foo'
+let fuz = "fuz" // double quote not preferred
+let foz = 'foz'
 
 // multiline-ternary
 // operator-linebreak
-let fiz = foo ? foo : // inconsistent line break
-    fuz;
+let fiz = foo ? foo // inconsistent line break
+: fuz;
 
 fiz = fiz ?
     fiz :
     foo ?
-        foo :
-        fuz; // operator before
+    foo
+    : fuz; // operator before
 
 // array-bracket-newline
-let arr = [ 1, 2, 3 ]; // space between brackets
-let azz = [
-    1, 2, // // no line break before multi-line array
+let arr = [ 1,2,3 ]; // space between brackets
+let azz = [ 1, 2, // // no line break before multi-line array
     3
 ];
 
 // space-infix-ops
-let math = 5 + 2 + 3; // no space between
+let math = 5+2+3; // no space between
 
 // space-unary-ops
-math++; // space between
+math ++ ; // space between
 
 // key-spacing (objects)
 // object-property-newline
 // quote-props
 let obj = {
-    shorter:      'short',
+    shorter:    'short',
     'longerName': 'long',
     'quote-prop': 'required quotes',
-    '123':        '123' // numbers must have quotes
+    123:        '123' // numbers must have quotes
 };
 
 // object-curly-newline
 let inline_obj = {foo, fuz, fiz};
-let inline_long_obj = {
-    foo, fuz, fiz, foz
-}; // too long
+let inline_long_obj = { foo, fuz, fiz, foz }; // too long
 
 // rest-spread-spacing
-let spread_obj = { ...inline_obj}; // space between spread
+let spread_obj = { ... inline_obj}; // space between spread
 
 
 // arrow parens
 let bar = () => {};
 
-let baz = foo => 'baz'; // parens not needed
+let baz = (foo) => 'baz'; // parens not needed
 
 // block spacing
 let bab = (foo, fuz) => { return true; };
 
 // function-call-argument-newline
 bab(foo, fuz);
-bab(
-    foo, // needs newline for multi-line
+bab(foo, // needs newline for multi-line
     fuz
 );
 
 // function-call-spacing
-if (foo) bar(); // spaces
+if (foo) bar () ; // spaces
 
 // brace styles 
 // space-before-blocks
-if (foo) { // bracket in wrong location
+if (foo) 
+{ // bracket in wrong location
     bar();
-} else if (fuz) {
+} 
+else if (fuz) {
     bar();
-} else { // else in wrong location
+}
+ else { // else in wrong location
     baz();
 }
 
@@ -88,7 +87,7 @@ class Foo {
     }
 
     // computed property spacing for classes
-    [baz()] () { // spaces in property name
+    [ baz() ] () { // spaces in property name
         return this;
     }
 }
@@ -97,16 +96,14 @@ class Foo {
 // new-parens
 // dot-location
 new Foo().baz() // inconsistent chaining
-    .baz() // dot should be before prop
-    .foo;
-new Foo().baz().baz()
-    .baz()
-    .baz().foo; // too long
+    .baz(). // dot should be before prop
+    foo;
+new Foo().baz().baz().baz().baz().foo; // too long
 
 // switch-colon-spacing
 switch (foo) {
-case 'foo': break; // space after case 'foo'
-case 'bar': break;
+case 'foo'  : break; // space after case 'foo'
+case 'bar'  : break;
 }
 
 // wrap-iife
@@ -115,7 +112,7 @@ case 'bar': break;
 (function() {})();
 
 // wrap regex
-(/foo/).test('bar'); // must wrap in parentheses
+/foo/.test('bar'); // must wrap in parentheses
 'foo'.replace(/foo/, 'bar'); // this is fine
 
 // eol-last: new line at EOF

--- a/examples/linterExample.js
+++ b/examples/linterExample.js
@@ -39,13 +39,14 @@ let obj = {
 };
 
 // object-curly-newline
-let inline_obj = {foo, fuz, fiz};
+// object-curly-spacing
+let inline_obj = { foo, fuz, fiz };
 let inline_long_obj = {
     foo, fuz, fiz, foz
 };
 
 // rest-spread-spacing
-let spread_obj = {...inline_obj};
+let spread_obj = { ...inline_obj };
 
 
 // arrow parens

--- a/examples/linterExample.js
+++ b/examples/linterExample.js
@@ -4,28 +4,48 @@
 
 let foo = 'foo';
 let fuz = 'fuz';
+let foz = 'foz';
 
 // multiline-ternary
+// operator-linebreak
 let fiz = foo ? foo : fuz;
-fiz = fiz?
+fiz = fiz ?
     fiz :
-    foo ? 
-        foo : 
+    foo ?
+        foo :
         fuz;
 
 // array-bracket-newline
 let arr = [1, 2, 3];
 let azz = [
-    1,
-    2, 
+    1, 2,
     3
 ];
 
+// space-infix-ops
+let math = 5 + 2 + 3;
+
+// space-unary-ops
+math++;
+
 // key-spacing (objects)
+// object-property-newline
+// quote-props
 let obj = {
-    short:      'short',
-    longerName: 'long'
+    'shorter':    'short',
+    'longerName': 'long',
+    'quote-prop': 'required quotes',
+    '123':        '123'
 };
+
+// object-curly-newline
+let inline_obj = {foo, fuz, fiz};
+let inline_long_obj = {
+    foo, fuz, fiz, foz
+};
+
+// rest-spread-spacing
+let spread_obj = {...inline_obj};
 
 
 // arrow parens
@@ -47,6 +67,7 @@ bab(
 if (foo) bar();
 
 // brace styles 
+// space-before-blocks
 if (foo) {
     bar();
 } else if (fuz) {
@@ -74,5 +95,19 @@ new Foo()
     .baz()
     .baz()
     .foo;
+
+// switch-colon-spacing
+switch (foo) {
+case 'foo': break;
+case 'bar': break;
+}
+
+// wrap-iife
+(function() {}());
+(function() {})();
+
+// wrap regex
+(/foo/).test('bar');
+'foo'.replace(/foo/, 'bar');
 
 // eol-last: new line at EOF

--- a/examples/linterExample.js
+++ b/examples/linterExample.js
@@ -1,0 +1,78 @@
+
+
+// semicolons required
+
+let foo = 'foo';
+let fuz = 'fuz';
+
+// multiline-ternary
+let fiz = foo ? foo : fuz;
+fiz = fiz?
+    fiz :
+    foo ? 
+        foo : 
+        fuz;
+
+// array-bracket-newline
+let arr = [1, 2, 3];
+let azz = [
+    1,
+    2, 
+    3
+];
+
+// key-spacing (objects)
+let obj = {
+    short:      'short',
+    longerName: 'long'
+};
+
+
+// arrow parens
+let bar = () => {};
+
+let baz = foo => 'baz';
+
+// block spacing
+let bab = (foo, fuz) => { return true; };
+
+// function-call-argument-newline
+bab(foo, fuz);
+bab(
+    foo,
+    fuz
+);
+
+// function-call-spacing
+if (foo) bar();
+
+// brace styles 
+if (foo) {
+    bar();
+} else if (fuz) {
+    bar();
+} else {
+    baz();
+}
+
+class Foo {
+    constructor() {
+        this.foo = foo;
+        this.fuz = fuz;
+    }
+
+    // computed property spacing for classes
+    [baz()] () {
+        return this;
+    }
+}
+
+// multiline-comment-style (currently disabled)
+// new-parens
+// dot-location
+new Foo()
+    .baz()
+    .baz()
+    .foo;
+
+// eol-last: new line at EOF

--- a/examples/linterExample.js
+++ b/examples/linterExample.js
@@ -95,7 +95,11 @@ class Foo {
 new Foo()
     .baz()
     .baz()
+    .baz()
     .foo;
+
+// chaining less than (3 I think) functions can be done inline
+new Foo().baz().baz();
 
 // switch-colon-spacing
 switch (foo) {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "test discord ai bot",
   "main": "./src/index.js",
   "scripts": {
-    "lint": "npx eslint src",
-    "lint:fix": "npx eslint --fix src",
+    "lint": "npx eslint src eslint.config.mjs",
+    "lint:fix": "npx eslint --fix src eslint.config.mjs",
+    "lint-example": "npx eslint examples/linterExample.js eslint.config.mjs",
+    "lint-example:fix": "npx eslint --fix examples/linterExample.js eslint.config.mjs",
     "setup": "git config core.hooksPath ./git_hooks",
     "prestart": "npm run setup",
     "start": "node ./src/index.js",


### PR DESCRIPTION
## Description
I went through the liberty of adding more ESLint formatting rules. Check the file [/examples/linterExample.js](/examples/linterExample.js) to see an example of a formatted file. Check the file [/examples/linterBadExample.js](/examples/linterBadExample.js) to see some examples of bad code that would be formatted.

## Future Work
- Add a GitHub workflow to automatically lint/format pull requests
- Format all existing files


## Formatting Example

```js


// semicolons required

let foo = 'foo';
let fuz = 'fuz';
let foz = 'foz';

// multiline-ternary
// operator-linebreak
let fiz = foo ? foo : fuz;
fiz = fiz ?
    fiz :
    foo ?
        foo :
        fuz;

// array-bracket-newline
let arr = [1, 2, 3];
let azz = [
    1, 2,
    3
];

// space-infix-ops
let math = 5 + 2 + 3;

// space-unary-ops
math++;

// key-spacing (objects)
// object-property-newline
// quote-props
let obj = {
    'shorter':    'short',
    'longerName': 'long',
    'quote-prop': 'required quotes',
    '123':        '123'
};

// object-curly-newline
// object-curly-spacing
let inline_obj = { foo, fuz, fiz };
let inline_long_obj = {
    foo, fuz, fiz, foz
};

// rest-spread-spacing
let spread_obj = { ...inline_obj };


// arrow parens
let bar = () => {};

let baz = foo => 'baz';

// block spacing
let bab = (foo, fuz) => { return true; };

// function-call-argument-newline
bab(foo, fuz);
bab(
    foo,
    fuz
);

// function-call-spacing
if (foo) bar();

// brace styles 
// space-before-blocks
if (foo) {
    bar();
} else if (fuz) {
    bar();
} else {
    baz();
}

class Foo {
    constructor() {
        this.foo = foo;
        this.fuz = fuz;
    }

    // computed property spacing for classes
    [baz()] () {
        return this;
    }
}

// multiline-comment-style (currently disabled)
// new-parens
// dot-location
new Foo()
    .baz()
    .baz()
    .foo;

// chaining less than (3 I think) functions can be done inline
new Foo().baz().baz();

// switch-colon-spacing
switch (foo) {
case 'foo': break;
case 'bar': break;
}

// wrap-iife
(function() {}());
(function() {})();

// wrap regex
(/foo/).test('bar');
'foo'.replace(/foo/, 'bar');

// eol-last: new line at EOF

```