### PR TITLE
Disabled no-use-before-define as per team's request

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,12 +32,14 @@ export default [
             'no-template-curly-in-string':   1,
             'no-unreachable-loop':           1,
             'no-unused-vars':                [2, { 'argsIgnorePattern': '^_$' }],
-            'no-use-before-define':          [2, { 'functions': false, 'classes': true, 'allowNamedExports': true }],
-            'no-useless-assignment':         1,
-            'require-atomic-updates':        0, // this causes false positives
-            'consistent-return':             2,
-            'no-else-return':                1,
-            'space-unary-ops':               2
+
+            // disabled because of false positives such as `const a = () => {}` (this is hoisted)
+            'no-use-before-define':   [0, { 'functions': false, 'classes': true, 'allowNamedExports': true }],
+            'no-useless-assignment':  1,
+            'require-atomic-updates': 0, // this causes false positives
+            'consistent-return':      2,
+            'no-else-return':         1,
+            'space-unary-ops':        2
         }
     },
     {


### PR DESCRIPTION
## Description

Our team likes to put functions at the bottom of their code, especially if they're helper functions and it makes the rest of the code more readable. The issue with eslint's `no-use-before-define` is that arrow functions such as `const a = () => {}` create false positives even though they're hoisted in ES6.